### PR TITLE
Auto-set the sass debug-info flag if not in Production

### DIFF
--- a/Class/Sass/Sass.class.php
+++ b/Class/Sass/Sass.class.php
@@ -14,6 +14,8 @@ public function __construct($filePath) {
 
 public function parse() {
 	$this->_sassParser = new SassParser();
+	$this->_sassParser->debug_info = !App_Config::isProduction();
+	
 	$parsedString = $this->_sassParser->toCss($this->_filePath);
 	return $parsedString;
 }


### PR DESCRIPTION
Allows sass to write-out the debug info to the processed CSS files -
info that can then be consumed by the firesass plugin etc to debug the
sass/ css files.

Rather than adding another setting, this commit sets the flag based on
the existing isProduction flag - so if isProduction is set to false, the
debug info is compiled-in/

Fixes #147.
