### PR TITLE
Add support for Composer

### DIFF
--- a/Framework/Autoloader.php
+++ b/Framework/Autoloader.php
@@ -16,6 +16,18 @@ if(class_exists("ClassDependencies")
 	return;
 }
 
+$composerAutoloader = "/vendor/autoload.php";
+$composerSearchPaths = array(
+	APPROOT . "/Class",
+	GTROOT . "/Class",
+	);
+foreach ($composerSearchPaths as $root) {
+	$pathToAutoloader = $root . $composerAutoloader;
+	if(file_exists($pathToAutoloader)) {
+		require_once($pathToAutoloader);
+	}
+}
+
 $configSuffix = "_Config";
 if(substr($className, -strlen($configSuffix)) === $configSuffix) {
 	$configFile = APPROOT . "/Config/$className.cfg.php";


### PR DESCRIPTION
Specifically, autoload the composer-generated autoloader file from both PHP.Gt and the project folder if they exist.
