### PR TITLE
Fix logger so passed-in config doesn't wipe all

### DIFF
--- a/Class/Log/Logger.class.php
+++ b/Class/Log/Logger.class.php
@@ -38,14 +38,7 @@ public function __construct($name, $config) {
 	$this->_file = "$name.log";
 	$this->_path = APPROOT;
 
-	// Import config variables here if they exist.
-	if(!empty($config)) {
-		foreach ($config as $key => $value) {
-			$var = "_$key";
-			$this->$var = $value;
-		}
-	}
-	else if(class_exists("Log_Config")) {
+	if(class_exists("Log_Config")) {
 		$this->importConfig();
 		if(isset(Log_Config::$logLevel)) {
 			$this->_logLevel = Log_Config::$logLevel;			
@@ -55,6 +48,14 @@ public function __construct($name, $config) {
 		}
 		if(isset(Log_Config::$datePattern)) {
 			$this->_datePattern = Log_Config::$datePattern;			
+		}
+	}
+
+	// Override them with the ones passed-in (if they exist)
+	if(!empty($config)) {
+		foreach ($config as $key => $value) {
+			$var = "_$key";
+			$this->$var = $value;
 		}
 	}
 }

--- a/Framework/Error/HttpError.php
+++ b/Framework/Error/HttpError.php
@@ -103,10 +103,6 @@ private function displayError($code, $data = array("")) {
 		}
 	}
 
-
-	if(count($data) === 1) {
-		$message = $data[0];
-	}
 	if(is_string($data)) {
 		$message = $data;
 	}


### PR DESCRIPTION
Currently, if you pass-in some config parameters when the Logger is
instantiated, the parameters that you DON'T pass in do not default to
those in the config file.  This fix means the passed-in parameters only
override those included in the passed-in array, and others not specified
are taken from the config file.

Also change HttpError class to remove line which generated an error of
its own in the log.
