### PR TITLE
Decouple ObjectDocument ready for extraction to own repo

### DIFF
--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -119,7 +119,9 @@ abstract class Dispatcher implements RequestHandlerInterface {
 				$view = $this->getView(
 					$response->getBody(),
 					"",
-					$templateDirectory
+					$templateDirectory,
+					null,
+					$request->getHeaderLine("accept")
 				);
 			}
 		}

--- a/src/Lifecycle.php
+++ b/src/Lifecycle.php
@@ -47,6 +47,7 @@ class Lifecycle implements MiddlewareInterface {
 	 * the Response object, allowing you to manipulate it elsewhere.
 	 */
 	public function start(bool $render = true):ResponseInterface {
+		ini_set("display_errors", true);
 		$server = new ServerInfo($_SERVER);
 
 		$cwd = dirname($server->getDocumentRoot());

--- a/src/Refactor/ObjectDocument.php
+++ b/src/Refactor/ObjectDocument.php
@@ -15,60 +15,6 @@ class ObjectDocument extends Document {
 		parent::__construct();
 
 		$this->type = $type;
-		if($this->isJsonString($document)) {
-			$this->loadJSON($document);
-		}
-		elseif($this->isXmlString($document)) {
-			$this->loadXML($document);
-		}
-		else {
-			throw new DocumentStringParseException("Unknown document type");
-		}
-	}
-
-	public function isJsonString(string $document):bool {
-		return $this->isFirstNonWhiteSpaceCharacter($document, "{[");
-	}
-
-	public function isXmlString(string $document):bool {
-		return $this->isFirstNonWhiteSpaceCharacter($document, "<");
-	}
-
-	protected function isFirstNonWhiteSpaceCharacter(
-		string $document,
-		string $firstCharMatch
-	):bool {
-		$i = 0;
-
-		do {
-			$char = $document[$i];
-			$i++;
-		}while(trim($char) === "");
-
-		for($i = 0; $i < strlen($firstCharMatch); $i++) {
-			$charMatch = $firstCharMatch[$i];
-			if($char === $charMatch) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * TODO: This function is not yet implemented. It acts as a placeholder until it is
-	 * extracted and implemented in its own repository, ObjectDocument.
-	 */
-	public function loadJSON(string $jsonString):void {
-		$json = json_decode($jsonString);
-
-		foreach($json as $key => $value) {
-			$valueType = gettype($value);
-			$stringValue = $this->getStringValue($valueType, $value);
-
-			$node = $this->createElement($key, $stringValue);
-			$this->appendChild($node);
-		}
 	}
 
 	public function __toString() {


### PR DESCRIPTION
Since ObjectDocument is being maintained within its own repository now, WebEngine has been decoupled from it as a dependency.

php.gt/objectdocument is the repository that will allow defining API views using XML schema documents, but this is still in development, so to allow WebEngine to respond to non-page requests, we can allow the construction of API responses manually in PHP logic, allowing the developer to choose their own mechanism for building responses.

Proposed solution:

    Check for XSD, use ObjectDocument if available.
    If not, check for PHP logic file, execute that anyway.
    404 only if XSD and PHP are both missing.


This closes #371 