### PR TITLE
Improve trailing slashes

### DIFF
--- a/router.default.php
+++ b/router.default.php
@@ -183,7 +183,8 @@ class DefaultRouter extends BaseRouter {
 
 	public function pathMatcherFilter(PathMatcher $pathMatcher):void {
 		$pathMatcher->addFilter(function(string $filePath, string $uriPath, string $baseDir):bool {
-			foreach(glob($baseDir . $uriPath . ".*") as $globMatch) {
+			$staticUriPath = rtrim($uriPath, "/");
+			foreach(glob($baseDir . $staticUriPath . ".*") as $globMatch) {
 				$URI_CONTAINER = pathinfo($uriPath, PATHINFO_DIRNAME);
 				$TRIM_THIS = $baseDir . $URI_CONTAINER;
 				if(str_starts_with($globMatch, $TRIM_THIS)) {

--- a/src/Dispatch/PathNormaliser.php
+++ b/src/Dispatch/PathNormaliser.php
@@ -2,6 +2,7 @@
 namespace GT\WebEngine\Dispatch;
 
 use Closure;
+use GT\Http\StatusCode;
 use Psr\Http\Message\UriInterface;
 
 class PathNormaliser {
@@ -14,12 +15,18 @@ class PathNormaliser {
 
 		if($forceTrailingSlash) {
 			if(!str_ends_with($path, "/")) {
-				$redirect($uri->withPath("$path/"));
+				$redirect(
+					$uri->withPath("$path/"),
+					StatusCode::PERMANENT_REDIRECT,
+				);
 			}
 		}
 		else {
 			if(str_ends_with($path, "/") && $path !== "/") {
-				$redirect($uri->withPath(rtrim($path, "/")));
+				$redirect(
+					$uri->withPath(rtrim($path, "/")),
+					StatusCode::PERMANENT_REDIRECT,
+				);
 			}
 		}
 	}

--- a/test/phpunit/DefaultRouterTest.php
+++ b/test/phpunit/DefaultRouterTest.php
@@ -271,6 +271,52 @@ class DefaultRouterTest extends TestCase {
 		self::assertSame(["page/article/read.html"], iterator_to_array($sut->getViewAssembly()));
 	}
 
+	public function testRoute_pageRequestWithTrailingSlash_ignoresDynamicCommonLogicWhenConcretePageExists():void {
+		mkdir($this->tmpDir . "/page/shop/@category", recursive: true);
+		file_put_contents(
+			$this->tmpDir . "/page/shop/@category/_common.php",
+			"<?php\nfunction dynamicCommon():void {}\n",
+		);
+		file_put_contents(
+			$this->tmpDir . "/page/shop/@category/index.php",
+			"<?php\nfunction dynamicPage():void {}\n",
+		);
+		file_put_contents(
+			$this->tmpDir . "/page/shop/static-product-page.html",
+			"<main>static product</main>",
+		);
+		file_put_contents(
+			$this->tmpDir . "/page/shop/static-product-page.php",
+			"<?php\nfunction staticPage():void {}\n",
+		);
+
+		chdir($this->tmpDir);
+
+		$request = self::createMock(Request::class);
+		$request->method("getMethod")->willReturn("GET");
+		$request->method("getHeaderLine")
+			->with("accept")
+			->willReturn("text/html");
+		$request->method("getUri")->willReturn(
+			new Uri("https://example.test/shop/static-product-page/"),
+		);
+
+		$sut = new DefaultRouter(new RouterConfig(307, "text/html"));
+		$container = new Container();
+		$container->set($request);
+		$sut->setContainer($container);
+		$sut->route($request);
+
+		self::assertSame(
+			["page/shop/static-product-page.php"],
+			iterator_to_array($sut->getLogicAssembly()),
+		);
+		self::assertSame(
+			["page/shop/static-product-page.html"],
+			iterator_to_array($sut->getViewAssembly()),
+		);
+	}
+
 	private function removeDirectory(string $dir):void {
 		if(!is_dir($dir)) {
 			return;

--- a/test/phpunit/Dispatch/DispatcherTest.php
+++ b/test/phpunit/Dispatch/DispatcherTest.php
@@ -82,7 +82,7 @@ class DispatcherTest extends TestCase {
 
 		$response = $sut->generateResponse();
 
-		self::assertSame(303, $response->getStatusCode());
+		self::assertSame(StatusCode::PERMANENT_REDIRECT, $response->getStatusCode());
 		self::assertSame("https://example.test/redirect-me/", $response->getHeaderLine("Location"));
 		self::assertSame($response, $finishedResponse);
 		self::assertNull($sut->getSessionInit());

--- a/test/phpunit/Dispatch/PathNormaliserTest.php
+++ b/test/phpunit/Dispatch/PathNormaliserTest.php
@@ -2,6 +2,7 @@
 namespace GT\WebEngine\Test\Dispatch;
 
 use GT\WebEngine\Dispatch\PathNormaliser;
+use GT\Http\StatusCode;
 use GT\Http\Uri;
 use PHPUnit\Framework\TestCase;
 
@@ -11,14 +12,17 @@ class PathNormaliserTest extends TestCase {
 		$uri = new Uri("https://example.test/section");
 		$called = false;
 		$redirected = null;
+		$statusCode = null;
 
-		$sut->normaliseTrailingSlash($uri, true, function(Uri $redirectUri) use (&$called, &$redirected) {
+		$sut->normaliseTrailingSlash($uri, true, function(Uri $redirectUri, int $redirectStatusCode) use (&$called, &$redirected, &$statusCode) {
 			$called = true;
 			$redirected = $redirectUri;
+			$statusCode = $redirectStatusCode;
 		});
 
 		self::assertTrue($called, "Expected redirect when missing trailing slash");
 		self::assertSame("/section/", $redirected->getPath());
+		self::assertSame(StatusCode::PERMANENT_REDIRECT, $statusCode);
 	}
 
 	public function testForceTrailingSlash_noopWhenAlreadyPresent():void {
@@ -66,12 +70,15 @@ class PathNormaliserTest extends TestCase {
 			$uri = new Uri("https://example.test/section/");
 			$called = false;
 			$redirected = null;
-			$sut->normaliseTrailingSlash($uri, false, function(Uri $u) use (&$called, &$redirected) {
+			$statusCode = null;
+			$sut->normaliseTrailingSlash($uri, false, function(Uri $u, int $redirectStatusCode) use (&$called, &$redirected, &$statusCode) {
 				$called = true;
 				$redirected = $u;
+				$statusCode = $redirectStatusCode;
 			});
 			self::assertTrue($called);
 			self::assertSame("/section", $redirected->getPath());
+			self::assertSame(StatusCode::PERMANENT_REDIRECT, $statusCode);
 		}
 	}
 


### PR DESCRIPTION
Static routes that are deeper than the current route should not execute their `_common` page logic. There was an edge case bug that allowed this, by the way the glob was being handled, which is now fixed.

Another fix here is that POST data is persisted through redirects, so it doesn't matter whether posting to a trailing slash page or not.